### PR TITLE
Great library, I use CSSEdit which is webkit based so I thought it would be nice to be able to use a vender prefix instead of having to use the base name:)

### DIFF
--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -28,7 +28,9 @@ def magic(ruleset, debug, minify):
             if not hasattr(rule, 'name'):#comments don't have name
                 rules.append(rule)
                 continue
-            rule.name = prefixRegex.sub('', rule.name)
+            name = prefixRegex.sub('', rule.name)
+            if name in tr_rules:
+                rule.name = name
             if rule.cssText in ruleSet:
                 continue
             ruleSet.add(rule.cssText)
@@ -40,7 +42,7 @@ def magic(ruleset, debug, minify):
                 ruleset.style.seq.append(rule, 'Comment')
                 continue
             processor = None
-            try:
+            try:#try except so if anything goes wrong we don't lose the original property
                 if rule.name in tr_rules:
                     processor = tr_rules[rule.name](rule)
                     [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props() if prop]

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -27,6 +27,9 @@ def magic(ruleset, debug, minify):
         ruleset.style = cssutils.css.CSSStyleDeclaration()#clear out the styles that were there
         rules = list()
         for rule in children:
+            if not hasattr(rule, 'name'):#comments don't have name
+                rules.append(rule)
+                continue
             rule.name = prefixRegex.sub('', rule.name)
             if rule.name in ruleSet:
                 continue
@@ -36,6 +39,9 @@ def magic(ruleset, debug, minify):
         rules.reverse()#now that we have unique rules flip the order back to what it was
         ruleset.style.seq._readonly = False
         for rule in rules:
+            if not hasattr(rule, 'name'):
+                ruleset.style.seq.append(rule, 'Comment')
+                continue        
             processor = None
             if rule.name in tr_rules:
                 processor = tr_rules[rule.name](rule)

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -46,7 +46,10 @@ def magic(ruleset, debug, minify):
     elif hasattr(ruleset, 'cssRules'):
         for subruleset in ruleset:
             magic(subruleset, debug, minify)
-    cssText = unicode(ruleset.cssText)
+    cssText = ruleset.cssText
+    if not cssText:#blank rules return None so return an empty string
+        return ''
+    cssText = unicode(cssText)
     if not minify:#if we are not minifying the css add a ; to the last property and remove the white space before the {
         cssText = re.sub('\n\s*}', ';\n}', cssText)
     return cssText
@@ -59,13 +62,12 @@ def process(string, debug=False, minify=False):
     else:
         cssutils.ser.prefs.useDefaults()
     sheet = parser.parseString(string)
-    result = ''
-    for ruleset in sheet.cssRules:
-        result += magic(ruleset, debug, minify)
-
+    
+    #format with newlines based on minify
+    joinStr = '' if minify else '\n\n'
     # Not using sheet.cssText - it's buggy:
     # it skips some prefixed properties.
-    return result
+    return joinStr.join((magic(ruleset, debug, minify) for ruleset in sheet.cssRules))
 
 __all__ = ('process')
 

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -20,7 +20,7 @@ from rules import rules as tr_rules
 
 prefixRegex = re.compile('^(-o-|-ms-|-moz-|-webkit-)')
 
-def magic(ruleset, debug):
+def magic(ruleset, debug, minify):
     if hasattr(ruleset, 'style'): # Comments don't
         ruleSet = set()
         children = list(ruleset.style.children())
@@ -45,8 +45,11 @@ def magic(ruleset, debug):
         ruleset.style.seq._readonly = True
     elif hasattr(ruleset, 'cssRules'):
         for subruleset in ruleset:
-            magic(subruleset, debug)
-    return unicode(ruleset.cssText)
+            magic(subruleset, debug, minify)
+    cssText = unicode(ruleset.cssText)
+    if not minify:#if we are not minifying the css add a ; to the last property and remove the white space before the {
+        cssText = re.sub('\n\s*}', ';\n}', cssText)
+    return cssText
 
 def process(string, debug=False, minify=False):
     if debug:
@@ -61,7 +64,7 @@ def process(string, debug=False, minify=False):
     sheet = parser.parseString(string)
     result = ''
     for ruleset in sheet.cssRules:
-        result += magic(ruleset, debug)
+        result += magic(ruleset, debug, minify)
 
     # Not using sheet.cssText - it's buggy:
     # it skips some prefixed properties.

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -40,13 +40,18 @@ def magic(ruleset, debug, minify):
                 ruleset.style.seq.append(rule, 'Comment')
                 continue
             processor = None
-            if rule.name in tr_rules:
-                processor = tr_rules[rule.name](rule)
-                [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props() if prop]
-            #always add the original rule
-            if processor and hasattr(processor, 'get_base_prop'):
-                ruleset.style.seq.append(processor.get_base_prop(), 'Property')
-            else:
+            try:
+                if rule.name in tr_rules:
+                    processor = tr_rules[rule.name](rule)
+                    [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props() if prop]
+                #always add the original rule
+                if processor and hasattr(processor, 'get_base_prop'):
+                    ruleset.style.seq.append(processor.get_base_prop(), 'Property')
+                else:
+                    ruleset.style.seq.append(rule, 'Property')
+            except:
+                if debug:
+                    print 'warning with ' + str(rule)
                 ruleset.style.seq.append(rule, 'Property')
         ruleset.style.seq._readonly = True
     elif hasattr(ruleset, 'cssRules'):

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -39,7 +39,7 @@ def magic(ruleset, debug, minify):
             processor = None
             if rule.name in tr_rules:
                 processor = tr_rules[rule.name](rule)
-                [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props()]
+                [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props() if prop]
             #always add the original rule
             if processor and hasattr(processor, 'get_base_prop'):
                 ruleset.style.seq.append(processor.get_base_prop(), 'Property')

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -37,9 +37,8 @@ def magic(ruleset, debug):
         rules.reverse()#now that we have unique rules flip the order back to what it was
         ruleset.style.seq._readonly = False
         for rule in rules:
-            ruleDef = tr_rules.get(rule.name)
-            if ruleDef:
-                processor = ruleDef(rule)
+            if rule.name in tr_rules:
+                processor = tr_rules[rule.name](rule)
                 [ruleset.style.seq.append(prop, 'Property') for prop in processor.get_prefixed_props()]
             #always add the original rule
             ruleset.style.seq.append(rule, 'Property')

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -21,10 +21,9 @@ from rules import prefixRegex
 
 def magic(ruleset, debug, minify):
     if hasattr(ruleset, 'style'): # Comments don't
-        ruleSet = set()
+        ruleSet = set(); rules = list()
         children = list(ruleset.style.children())
         ruleset.style = cssutils.css.CSSStyleDeclaration()#clear out the styles that were there
-        rules = list()
         for rule in children:
             if not hasattr(rule, 'name'):#comments don't have name
                 rules.append(rule)
@@ -34,12 +33,12 @@ def magic(ruleset, debug, minify):
                 continue
             ruleSet.add(rule.cssText)
             rules.append(rule)
-            
+
         ruleset.style.seq._readonly = False
         for rule in rules:
             if not hasattr(rule, 'name'):
                 ruleset.style.seq.append(rule, 'Comment')
-                continue        
+                continue
             processor = None
             if rule.name in tr_rules:
                 processor = tr_rules[rule.name](rule)
@@ -55,7 +54,7 @@ def magic(ruleset, debug, minify):
             magic(subruleset, debug, minify)
     cssText = ruleset.cssText
     if not cssText:#blank rules return None so return an empty string
-        return ''
+        return
     if minify or not hasattr(ruleset, 'style'):
         return unicode(cssText)
     return unicode(cssText)+'\n'
@@ -71,24 +70,19 @@ def process(string, debug=False, minify=False, **prefs):
     for key, value in prefs.iteritems():
         if hasattr(cssutils.ser.prefs, key):
             cssutils.ser.prefs.__dict__[key] = value
-    sheet = parser.parseString(string)
-    
+
     results = []
+    sheet = parser.parseString(string)
     for ruleset in sheet.cssRules:
         cssText = magic(ruleset, debug, minify)
         if cssText:
             results.append(cssText)
-            
+
     #format with newlines based on minify
     joinStr = '' if minify else '\n'
-    
+
     # Not using sheet.cssText - it's buggy:
     # it skips some prefixed properties.
     return joinStr.join(results).rstrip()
 
 __all__ = ('process')
-
-
-
-
-

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -49,7 +49,9 @@ def magic(ruleset, debug, minify):
     cssText = ruleset.cssText
     if not cssText:#blank rules return None so return an empty string
         return ''
-    return unicode(cssText)
+    if minify or not hasattr(ruleset, 'style'):
+        return unicode(cssText)
+    return unicode(cssText)+'\n'
 
 def process(string, debug=False, minify=False, **prefs):
     loglevel = 'info' if debug else 'error'
@@ -71,11 +73,11 @@ def process(string, debug=False, minify=False, **prefs):
             results.append(cssText)
             
     #format with newlines based on minify
-    joinStr = '' if minify else '\n\n'
+    joinStr = '' if minify else '\n'
     
     # Not using sheet.cssText - it's buggy:
     # it skips some prefixed properties.
-    return joinStr.join(results)
+    return joinStr.join(results).rstrip()
 
 __all__ = ('process')
 

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -51,13 +51,17 @@ def magic(ruleset, debug, minify):
         return ''
     return unicode(cssText)
 
-def process(string, debug=False, minify=False):
+def process(string, debug=False, minify=False, **prefs):
     loglevel = 'info' if debug else 'error'
     parser = cssutils.CSSParser(loglevel=loglevel)
     if minify:
         cssutils.ser.prefs.useMinified()
     else:
         cssutils.ser.prefs.useDefaults()
+    #use the passed in prefs
+    for key, value in prefs.iteritems():
+        if hasattr(cssutils.ser.prefs, key):
+            cssutils.ser.prefs.__dict__[key] = value
     sheet = parser.parseString(string)
     
     results = []

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -49,10 +49,7 @@ def magic(ruleset, debug, minify):
     cssText = ruleset.cssText
     if not cssText:#blank rules return None so return an empty string
         return ''
-    cssText = unicode(cssText)
-    if not minify:#if we are not minifying the css add a ; to the last property and remove the white space before the {
-        cssText = re.sub('\n\s*}', ';\n}', cssText)
-    return cssText
+    return unicode(cssText)
 
 def process(string, debug=False, minify=False):
     loglevel = 'info' if debug else 'error'
@@ -63,11 +60,18 @@ def process(string, debug=False, minify=False):
         cssutils.ser.prefs.useDefaults()
     sheet = parser.parseString(string)
     
+    results = []
+    for ruleset in sheet.cssRules:
+        cssText = magic(ruleset, debug, minify)
+        if cssText:
+            results.append(cssText)
+            
     #format with newlines based on minify
     joinStr = '' if minify else '\n\n'
+    
     # Not using sheet.cssText - it's buggy:
     # it skips some prefixed properties.
-    return joinStr.join((magic(ruleset, debug, minify) for ruleset in sheet.cssRules))
+    return joinStr.join(results)
 
 __all__ = ('process')
 

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -23,7 +23,6 @@ def magic(ruleset, debug, minify):
     if hasattr(ruleset, 'style'): # Comments don't
         ruleSet = set()
         children = list(ruleset.style.children())
-        children.reverse()#reverse the children so the last style is the one that wins
         ruleset.style = cssutils.css.CSSStyleDeclaration()#clear out the styles that were there
         rules = list()
         for rule in children:
@@ -31,12 +30,11 @@ def magic(ruleset, debug, minify):
                 rules.append(rule)
                 continue
             rule.name = prefixRegex.sub('', rule.name)
-            if rule.name in ruleSet:
+            if rule.cssText in ruleSet:
                 continue
-            ruleSet.add(rule.name)
+            ruleSet.add(rule.cssText)
             rules.append(rule)
             
-        rules.reverse()#now that we have unique rules flip the order back to what it was
         ruleset.style.seq._readonly = False
         for rule in rules:
             if not hasattr(rule, 'name'):

--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -52,10 +52,7 @@ def magic(ruleset, debug, minify):
     return cssText
 
 def process(string, debug=False, minify=False):
-    if debug:
-        loglevel = 'info'
-    else:
-        loglevel = 'error'
+    loglevel = 'info' if debug else 'error'
     parser = cssutils.CSSParser(loglevel=loglevel)
     if minify:
         cssutils.ser.prefs.useMinified()

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -31,7 +31,7 @@ class BaseReplacementRule(object):
                     value=self.prop.value,
                     priority=self.prop.priority
                     )
-        
+
     @staticmethod
     def should_prefix():
         return True
@@ -79,14 +79,14 @@ class DisplayReplacementRule(BaseReplacementRule):
         if self.prop.value == 'box':#only add prefixes if the value is box
             for prefix in self.vendor_prefixes:
                 yield cssutils.css.Property(
-                        name='display', 
-                        value='-%s-box' % prefix, 
+                        name='display',
+                        value='-%s-box' % prefix,
                         priority=self.prop.priority
                         )
 
 class TransitionReplacementRule(BaseReplacementRule):
     vendor_prefixes = ['webkit', 'moz', 'o']
-    
+
     def __get_prefixed_prop(self, prefix=None):
         name = self.prop.name
         if prefix:
@@ -103,11 +103,11 @@ class TransitionReplacementRule(BaseReplacementRule):
                 value=', '.join(newValues),
                 priority=self.prop.priority
                 )
-    
+
     def get_prefixed_props(self):
         for prefix in self.vendor_prefixes:
             yield self.__get_prefixed_prop(prefix)
-        
+
     def get_base_prop(self):
         return self.__get_prefixed_prop()
 
@@ -124,14 +124,14 @@ class OpacityReplacementRule(BaseReplacementRule):
                 value='alpha(opacity=%d)' % ieValue,
                 priority=self.prop.priority
                 )
-        
+
     @staticmethod
     def should_prefix():
-        return False        
+        return False
 
 class GradientReplacementRule(BaseReplacementRule):
     vendor_prefixes = ['webkit', 'moz', 'o']
-    
+
     def __iter_values(self):
         valueSplit = self.prop.value.split(',')
         index = 0
@@ -157,7 +157,7 @@ class GradientReplacementRule(BaseReplacementRule):
                         'pos': values[0],
                         'start': values[1],
                         'end': values[2]
-                        }                    
+                        }
                 index += len(values)
             elif snip.startswith('gradient'):
                 yield {
@@ -169,7 +169,7 @@ class GradientReplacementRule(BaseReplacementRule):
                 #not a gradient so just yield the raw string
                 yield snip
                 index += 1
-                
+
     def __get_prefixed_prop(self, values, prefix=None):
         gradientName = 'linear-gradient'
         if prefix:
@@ -188,7 +188,7 @@ class GradientReplacementRule(BaseReplacementRule):
                 value=', '.join(newValues),
                 priority=self.prop.priority
                 )
-                
+
     def get_prefixed_props(self):
         values = list(self.__iter_values())
         needPrefix = False
@@ -205,7 +205,7 @@ class GradientReplacementRule(BaseReplacementRule):
                         if isinstance(value, dict):
                             newValues.append('-webkit-gradient(linear, left top, left bottom, color-stop(0, %(start)s), color-stop(1, %(end)s))' % value)
                         else:
-                            newValues.append(value)                        
+                            newValues.append(value)
                     yield cssutils.css.Property(
                             name=self.prop.name,
                             value=', '.join(newValues),
@@ -222,10 +222,10 @@ class GradientReplacementRule(BaseReplacementRule):
                     break
         else:
             yield None
-            
+
     def get_base_prop(self):
         values = self.__iter_values()
-        return self.__get_prefixed_prop(values)            
+        return self.__get_prefixed_prop(values)
 
 rules = {
     'border-radius': BaseReplacementRule,
@@ -275,6 +275,6 @@ rules = {
     'transform-origin': FullReplacementRule,
 
     'display': DisplayReplacementRule,
-    
-    'opacity': OpacityReplacementRule,    
+
+    'opacity': OpacityReplacementRule,
 }

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -75,7 +75,11 @@ class DisplayReplacementRule(BaseReplacementRule):
         props = []
         if self.prop.value == 'box':#only add prefixes if the value is box
             for prefix in self.vendor_prefixes:
-                props.append(cssutils.css.Property(name='display', value='-%s-box' % prefix, priority=self.prop.priority))
+                props.append(cssutils.css.Property(
+                    name='display', 
+                    value='-%s-box' % prefix, 
+                    priority=self.prop.priority
+                    ))
         return props
 
 rules = {

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -18,7 +18,6 @@ import cssutils
 
 class BaseReplacementRule(object):
     vendor_prefixes = ['webkit', 'moz']
-    add_to_sheet = ''
 
     def __init__(self, prop):
         self.prop = prop
@@ -74,9 +73,11 @@ class DisplayReplacementRule(BaseReplacementRule):
     """
     vendor_prefixes = []
 
-    def replace_hook(self, text):
-        return re.sub(r'display: ?box', # Supporting both minified and original
-                      'display:-webkit-box;display:-moz-box;display:box', text)
+    def get_prefixed_props(self):
+        return [
+            cssutils.css.Property(name='display', value='-webkit-box', priority=self.prop.priority),
+            cssutils.css.Property(name='display', value='-moz-box', priority=self.prop.priority)
+        ]
 
 rules = {
     'border-radius': BaseReplacementRule,

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -88,29 +88,21 @@ class TransitionReplacementRule(BaseReplacementRule):
     vendor_prefixes = ['webkit', 'moz', 'o']
     
     def __get_prefixed_prop(self, prefix=None):
-        #transition-property is the easy one...
         name = self.prop.name
         if prefix:
-            name = '-%s-%s' % (prefix, self.prop.name)        
-        if self.prop.name == 'transition-property':
-            values = self.prop.value.split(',')
-            newValues = []
-            for value in values:
-                value = prefixRegex.sub('', value.strip())
-                if value in rules and prefix:
-                    newValues.append('-%s-%s' % (prefix, value))
-                else:
-                    newValues.append(value)
-            return cssutils.css.Property(
-                    name=name,
-                    value=', '.join(newValues),
-                    priority=self.prop.priority
-                    )
+            name = '-%s-%s' % (prefix, self.prop.name)
+        newValues = []
+        for value in self.prop.value.split(','):
+            parts = value.strip().split(' ')
+            parts[0] = prefixRegex.sub('', parts[0])
+            if parts[0] in rules and prefix:
+                parts[0] = '-%s-%s' % (prefix, parts[0])
+            newValues.append(' '.join(parts))
         return cssutils.css.Property(
-            name=name,
-            value=self.prop.value,
-            priority=self.prop.priority
-            )
+                name=name,
+                value=', '.join(newValues),
+                priority=self.prop.priority
+                )
     
     def get_prefixed_props(self):
         props = []

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -275,6 +275,6 @@ rules = {
     'transform-origin': FullReplacementRule,
 
     'display': DisplayReplacementRule,
-
     'opacity': OpacityReplacementRule,
+    'appearance': WebkitReplacementRule,
 }

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -71,13 +71,12 @@ class DisplayReplacementRule(BaseReplacementRule):
     Flexible Box Model stuff.
     CSSUtils parser doesn't support duplicate properties, so that's dirty.
     """
-    vendor_prefixes = []
-
     def get_prefixed_props(self):
-        return [
-            cssutils.css.Property(name='display', value='-webkit-box', priority=self.prop.priority),
-            cssutils.css.Property(name='display', value='-moz-box', priority=self.prop.priority)
-        ]
+        props = []
+        if self.prop.value == 'box':#only add prefixes if the value is box
+            for prefix in self.vendor_prefixes:
+                props.append(cssutils.css.Property(name='display', value='-%s-box' % prefix, priority=self.prop.priority))
+        return props
 
 rules = {
     'border-radius': BaseReplacementRule,

--- a/tests.py
+++ b/tests.py
@@ -380,7 +380,20 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
     background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), linear-gradient(top, #444, #999)
     }''')
-
+    
+    #cssutils cannot parse this rule
+    def _test_background_multiple_images_and_gradients(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image:
+        url('../img/arrow.png'),
+        -webkit-gradient(
+        linear,
+        left top,
+        left bottom,
+        from(rgb(240, 240, 240)),
+        to(rgb(210, 210, 210))
+    )}''', minify=False), '''.box_gradient {
+    }''')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -105,7 +105,6 @@ class PrefixerTestCase(unittest.TestCase):
     transition-duration: rotatey(45deg), 2s, 4s
     }''')
     
-    
     def test_opacity(self):
         self.assertEqual(cssprefixer.process('''a {
     opacity: 0.25;
@@ -222,6 +221,136 @@ class IePrefixerTestCase(unittest.TestCase):
     def test_ie_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-ms-text-overflow: ellipsis}', minify=True),
                          'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')   
-                         
+             
+class GradientTestCase(unittest.TestCase):            
+    def test_basic(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: linear-gradient(top, #444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(top, #444, #999);
+    background-image: -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999)
+    }''') 
+
+    def test_webkit(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(top, #444, #999);
+    background-image: -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999)
+    }''')  
+        
+    def test_webkit_mixed(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444444, #999999), linear-gradient(top, black, white);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999), -webkit-linear-gradient(top, black, white);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white));
+    background-image: -moz-linear-gradient(top, #444, #999), -moz-linear-gradient(top, black, white);
+    background-image: -o-linear-gradient(top, #444, #999), -o-linear-gradient(top, black, white);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999), linear-gradient(top, black, white)
+    }''')  
+    
+    def test_moz(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -moz-linear-gradient(top, #444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(top, #444, #999);
+    background-image: -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999)
+    }''') 
+    
+    def test_o(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -o-linear-gradient(top, #444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(top, #444, #999);
+    background-image: -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999)
+    }''')
+    
+    def test_webkit_gradient(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(top, #444, #999);
+    background-image: -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999)
+    }''')
+    
+    def test_webkit_gradient_mixed(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-linear-gradient(top, black, white);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(top, #444, #999), -webkit-linear-gradient(top, black, white);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white));
+    background-image: -moz-linear-gradient(top, #444, #999), -moz-linear-gradient(top, black, white);
+    background-image: -o-linear-gradient(top, #444, #999), -o-linear-gradient(top, black, white);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(top, #444, #999), linear-gradient(top, black, white)
+    }''')
+    
+    def test_image(self):
+        #I don't think this test produces valid css but it shows that data and order is being preserved.
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: url(images/background.png), linear-gradient(top, black, white);
+    }''', minify=False), '''.box_gradient {
+    background-image: url(images/background.png), -webkit-linear-gradient(top, black, white);
+    background-image: url(images/background.png), -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white));
+    background-image: url(images/background.png), -moz-linear-gradient(top, black, white);
+    background-image: url(images/background.png), -o-linear-gradient(top, black, white);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
+    background-image: url(images/background.png), linear-gradient(top, black, white)
+    }''')
+    
+    def test_background_multiple_images(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background: url(images/cross.png), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    }''', minify=False), '''.box_gradient {
+    background: url(images/cross.png), url(images/gradient.png) top center no-repeat, url(images/background.png)
+    }''') 
+    
+    def test_background_multiple_images_and_gradient(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    }''', minify=False), '''.box_gradient {
+    background: -webkit-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white)), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    background: -moz-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    background: -o-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
+    background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png)
+    }''')
+    
+    def test_background_multiple_images_and_gradients(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), -moz-linear-gradient(top, #444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background: -webkit-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), -webkit-linear-gradient(top, #444, #999);
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white)), url(images/gradient.png) top center no-repeat, url(images/background.png), -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background: -moz-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), -moz-linear-gradient(top, #444, #999);
+    background: -o-linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), -o-linear-gradient(top, #444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
+    background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), linear-gradient(top, #444, #999)
+    }''')
+
+  
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -20,11 +20,11 @@ import cssprefixer
 class PrefixerTestCase(unittest.TestCase):
     def test_common(self):
         self.assertEqual(cssprefixer.process('a{border-radius: 1em}', minify=True),
-                         'a{-moz-border-radius:1em;-webkit-border-radius:1em;border-radius:1em}')
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
 
     def test_common_and_opera(self):
         self.assertEqual(cssprefixer.process('a{transform: rotate(10deg)}', minify=True),
-                         'a{-o-transform:rotate(10deg);-moz-transform:rotate(10deg);-webkit-transform:rotate(10deg);transform:rotate(10deg)}')
+                         'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
 
     def test_webkit(self):
         self.assertEqual(cssprefixer.process('a{background-clip: padding-box}', minify=True),
@@ -32,11 +32,11 @@ class PrefixerTestCase(unittest.TestCase):
 
     def test_ie_and_opera(self):
         self.assertEqual(cssprefixer.process('a{text-overflow: ellipsis}', minify=True),
-                         'a{-ms-text-overflow:ellipsis;-o-text-overflow:ellipsis;text-overflow:ellipsis}')
+                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')
 
     def test_moz_border_radius(self):
         self.assertEqual(cssprefixer.process('a{border-top-left-radius: 1em;border-top-right-radius: 1em;border-bottom-right-radius: 1em;border-bottom-left-radius: 1em;}', minify=True),
-                         'a{-moz-border-radius-topleft:1em;-moz-border-radius-topright:1em;-moz-border-radius-bottomright:1em;-moz-border-radius-bottomleft:1em;-webkit-border-bottom-left-radius:1em;-webkit-border-bottom-right-radius:1em;-webkit-border-top-right-radius:1em;-webkit-border-top-left-radius:1em;border-top-left-radius:1em;border-top-right-radius:1em;border-bottom-right-radius:1em;border-bottom-left-radius:1em}')
+                         'a{-webkit-border-top-left-radius:1em;-moz-border-radius-topleft:1em;border-top-left-radius:1em;-webkit-border-top-right-radius:1em;-moz-border-radius-topright:1em;border-top-right-radius:1em;-webkit-border-bottom-right-radius:1em;-moz-border-radius-bottomright:1em;border-bottom-right-radius:1em;-webkit-border-bottom-left-radius:1em;-moz-border-radius-bottomleft:1em;border-bottom-left-radius:1em}')
 
     def test_flexbox(self):
         self.assertEqual(cssprefixer.process('a{display: box;}', minify=True),
@@ -45,6 +45,78 @@ class PrefixerTestCase(unittest.TestCase):
     def test_mq(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{color:red}}', minify=True),
                          '@media screen and (min-width:480px){a{color:red}}')
+                         
+    def test_mq_common(self):
+        self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{border-radius: 1em}}', minify=True),
+                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')
+                         
+    def test_duplicate_common(self):
+        self.assertEqual(cssprefixer.process('a{border-radius: 1em;border-radius: 2em;border-radius: 3em}', minify=True),
+                         'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
+                         
+    def test_mixed_common(self):
+        self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
+                         'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
+                         
+class WebkitPrefixerTestCase(unittest.TestCase):
+    def test_common(self):
+        self.assertEqual(cssprefixer.process('a{-webkit-border-radius: 1em}', minify=True),
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
+                         
+    def test_common_and_opera(self):
+        self.assertEqual(cssprefixer.process('a{-webkit-transform: rotate(10deg)}', minify=True),
+                         'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
+                         
+    def test_webkit(self):
+        self.assertEqual(cssprefixer.process('a{-webkit-background-clip: padding-box}', minify=True),
+                         'a{-webkit-background-clip:padding-box;background-clip:padding-box}')
 
+    def test_moz_border_radius(self):
+        self.assertEqual(cssprefixer.process('a{-webkit-border-top-left-radius: 1em;-webkit-border-top-right-radius: 1em;-webkit-border-bottom-right-radius: 1em;-webkit-border-bottom-left-radius: 1em;}', minify=True),
+                         'a{-webkit-border-top-left-radius:1em;-moz-border-radius-topleft:1em;border-top-left-radius:1em;-webkit-border-top-right-radius:1em;-moz-border-radius-topright:1em;border-top-right-radius:1em;-webkit-border-bottom-right-radius:1em;-moz-border-radius-bottomright:1em;border-bottom-right-radius:1em;-webkit-border-bottom-left-radius:1em;-moz-border-radius-bottomleft:1em;border-bottom-left-radius:1em}')
+                         
+    def test_flexbox(self):
+        self.assertEqual(cssprefixer.process('a{-webkit-display: box;}', minify=True),
+                         'a{display:-webkit-box;display:-moz-box;display:box}')
+                         
+    def test_mq_common(self):
+        self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{-webkit-border-radius: 1em}}', minify=True),
+                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')                           
+                         
+class MozPrefixerTestCase(unittest.TestCase):
+    def test_common(self):
+        self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em}', minify=True),
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
+                         
+    def test_common_and_opera(self):
+        self.assertEqual(cssprefixer.process('a{-moz-transform: rotate(10deg)}', minify=True),
+                         'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
+                         
+    def test_moz_border_radius(self):
+        self.assertEqual(cssprefixer.process('a{-moz-border-top-left-radius: 1em;-moz-border-top-right-radius: 1em;-moz-border-bottom-right-radius: 1em;-moz-border-bottom-left-radius: 1em;}', minify=True),
+                         'a{-webkit-border-top-left-radius:1em;-moz-border-radius-topleft:1em;border-top-left-radius:1em;-webkit-border-top-right-radius:1em;-moz-border-radius-topright:1em;border-top-right-radius:1em;-webkit-border-bottom-right-radius:1em;-moz-border-radius-bottomright:1em;border-bottom-right-radius:1em;-webkit-border-bottom-left-radius:1em;-moz-border-radius-bottomleft:1em;border-bottom-left-radius:1em}')
+                         
+    def test_flexbox(self):
+        self.assertEqual(cssprefixer.process('a{-moz-display: box;}', minify=True),
+                         'a{display:-webkit-box;display:-moz-box;display:box}')  
+                         
+    def test_mq_common(self):
+        self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{-moz-border-radius: 1em}}', minify=True),
+                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')                        
+                         
+class OperaPrefixerTestCase(unittest.TestCase):
+    def test_common_and_opera(self):
+        self.assertEqual(cssprefixer.process('a{-o-transform: rotate(10deg)}', minify=True),
+                         'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
+                         
+    def test_ie_and_opera(self):
+        self.assertEqual(cssprefixer.process('a{-o-text-overflow: ellipsis}', minify=True),
+                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')                         
+
+class IePrefixerTestCase(unittest.TestCase):
+    def test_ie_and_opera(self):
+        self.assertEqual(cssprefixer.process('a{-ms-text-overflow: ellipsis}', minify=True),
+                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')   
+                         
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -62,6 +62,28 @@ class PrefixerTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
                          'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
                          
+    def test_no_mini(self):
+        self.assertEqual(cssprefixer.process('''.my-class, #my-id {
+    border-radius: 1em;
+    transition: all 1s ease;
+    box-shadow: #123456 0 0 10px;
+    display: box;
+}''', minify=False), '''.my-class, #my-id {
+    -webkit-border-radius: 1em;
+    -moz-border-radius: 1em;
+    border-radius: 1em;
+    -webkit-transition: all 1s ease;
+    -moz-transition: all 1s ease;
+    -o-transition: all 1s ease;
+    transition: all 1s ease;
+    -webkit-box-shadow: #123456 0 0 10px;
+    -moz-box-shadow: #123456 0 0 10px;
+    box-shadow: #123456 0 0 10px;
+    display: -webkit-box;
+    display: -moz-box;
+    display: box;
+}''')
+                         
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):
         self.assertEqual(cssprefixer.process('a{-webkit-border-radius: 1em}', minify=True),

--- a/tests.py
+++ b/tests.py
@@ -161,6 +161,23 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
     display: block
     }''')
+    
+    def test_inline_comment(self):
+        #TODO: it would be nice if comments on the same line remained there, but this may not be possible because
+        #cssutils tears everything apart into objects and then we rebuild it.
+        self.assertEqual(cssprefixer.process('''article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    display: block;/* HTML5 display-role reset for older browsers */
+    }''', minify=False), '''article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    display: block;
+    /* HTML5 display-role reset for older browsers */
+    }''')
+        self.assertEqual(cssprefixer.process('''article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    /* HTML5 display-role reset for older browsers */
+    display: block;
+    }''', minify=False), '''article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    /* HTML5 display-role reset for older browsers */
+    display: block
+    }''')        
                          
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):

--- a/tests.py
+++ b/tests.py
@@ -41,7 +41,7 @@ class PrefixerTestCase(unittest.TestCase):
     def test_flexbox(self):
         self.assertEqual(cssprefixer.process('a{display: box;}', minify=True),
                          'a{display:-webkit-box;display:-moz-box;display:box}')
-                         
+
     def test_displaybox(self):
         self.assertEqual(cssprefixer.process('a{display: display;}', minify=True),
                          'a{display:display}')
@@ -49,18 +49,22 @@ class PrefixerTestCase(unittest.TestCase):
     def test_mq(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{color:red}}', minify=True),
                          '@media screen and (min-width:480px){a{color:red}}')
-                         
+
     def test_mq_common(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{border-radius: 1em}}', minify=True),
                          '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')
-                         
+
     def test_duplicate_common(self):
         self.assertEqual(cssprefixer.process('a{border-radius: 1em;border-radius: 2em;border-radius: 3em}', minify=True),
                          'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em;-webkit-border-radius:2em;-moz-border-radius:2em;border-radius:2em;-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
-                         
+
     def test_mixed_common(self):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
                          'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em;-webkit-border-radius:2em;-moz-border-radius:2em;border-radius:2em;-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
+
+    def test_mixed_duplicate(self):
+        self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 1em;-webkit-border-radius: 1em}', minify=True),
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
 
     def test_transition(self):
         self.assertEqual(cssprefixer.process('''div {
@@ -71,10 +75,7 @@ class PrefixerTestCase(unittest.TestCase):
     -o-transition: color 0.25s linear, -o-transform 0.15s linear 0.1s;
     transition: color 0.25s linear, transform 0.15s linear 0.1s
     }''')
-    
-    #This test failes but it shouln't.
-    #This failes becuase duplicate properties are removed,
-    #this duplicate property is valid and useful.
+
     def test_multi_transition(self):
         self.assertEqual(cssprefixer.process('''div {
     transition: color .25s linear;
@@ -89,7 +90,7 @@ class PrefixerTestCase(unittest.TestCase):
     -o-transition: background-color 0.15s linear 0.1;
     transition: background-color 0.15s linear 0.1
     }''')
-             
+
     def test_transition_property(self):
         self.assertEqual(cssprefixer.process('''div {
     -webkit-transition-property: -webkit-transform, opacity, left;
@@ -104,7 +105,7 @@ class PrefixerTestCase(unittest.TestCase):
     -o-transition-duration: rotatey(45deg), 2s, 4s;
     transition-duration: rotatey(45deg), 2s, 4s
     }''')
-    
+
     def test_opacity(self):
         self.assertEqual(cssprefixer.process('''a {
     opacity: 0.25;
@@ -112,8 +113,8 @@ class PrefixerTestCase(unittest.TestCase):
     -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)";
     filter: alpha(opacity=25);
     opacity: 0.25
-    }''')    
-                 
+    }''')
+
     def test_no_mini(self):
         self.assertEqual(cssprefixer.process('''.my-class, #my-id {
     border-radius: 1em;
@@ -139,7 +140,7 @@ class PrefixerTestCase(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(cssprefixer.process('a{}', minify=True), '')
         self.assertEqual(cssprefixer.process('a{}', minify=False), '')
-        
+
     def test_media_no_mini(self):
         self.assertEqual(cssprefixer.process('''@media screen and (max-device-width: 480px){
     #book{
@@ -152,7 +153,7 @@ class PrefixerTestCase(unittest.TestCase):
         border-radius: 1em
         }
     }''')
-    
+
     def test_comment(self):
         self.assertEqual(cssprefixer.process('''/* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
@@ -161,7 +162,7 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
 article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
     display: block
     }''')
-    
+
     def test_inline_comment(self):
         #TODO: it would be nice if comments on the same line remained there, but this may not be possible because
         #cssutils tears everything apart into objects and then we rebuild it.
@@ -177,17 +178,17 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
     }''', minify=False), '''article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
     /* HTML5 display-role reset for older browsers */
     display: block
-    }''')        
-                         
+    }''')
+
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):
         self.assertEqual(cssprefixer.process('a{-webkit-border-radius: 1em}', minify=True),
                          'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
-                         
+
     def test_common_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-webkit-transform: rotate(10deg)}', minify=True),
                          'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
-                         
+
     def test_webkit(self):
         self.assertEqual(cssprefixer.process('a{-webkit-background-clip: padding-box}', minify=True),
                          'a{-webkit-background-clip:padding-box;background-clip:padding-box}')
@@ -195,50 +196,50 @@ class WebkitPrefixerTestCase(unittest.TestCase):
     def test_moz_border_radius(self):
         self.assertEqual(cssprefixer.process('a{-webkit-border-top-left-radius: 1em;-webkit-border-top-right-radius: 1em;-webkit-border-bottom-right-radius: 1em;-webkit-border-bottom-left-radius: 1em;}', minify=True),
                          'a{-webkit-border-top-left-radius:1em;-moz-border-radius-topleft:1em;border-top-left-radius:1em;-webkit-border-top-right-radius:1em;-moz-border-radius-topright:1em;border-top-right-radius:1em;-webkit-border-bottom-right-radius:1em;-moz-border-radius-bottomright:1em;border-bottom-right-radius:1em;-webkit-border-bottom-left-radius:1em;-moz-border-radius-bottomleft:1em;border-bottom-left-radius:1em}')
-                         
+
     def test_flexbox(self):
         self.assertEqual(cssprefixer.process('a{-webkit-display: box;}', minify=True),
                          'a{display:-webkit-box;display:-moz-box;display:box}')
-                         
+
     def test_mq_common(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{-webkit-border-radius: 1em}}', minify=True),
-                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')                           
-                         
+                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')
+
 class MozPrefixerTestCase(unittest.TestCase):
     def test_common(self):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em}', minify=True),
                          'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}')
-                         
+
     def test_common_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-moz-transform: rotate(10deg)}', minify=True),
                          'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
-                         
+
     def test_moz_border_radius(self):
         self.assertEqual(cssprefixer.process('a{-moz-border-top-left-radius: 1em;-moz-border-top-right-radius: 1em;-moz-border-bottom-right-radius: 1em;-moz-border-bottom-left-radius: 1em;}', minify=True),
                          'a{-webkit-border-top-left-radius:1em;-moz-border-radius-topleft:1em;border-top-left-radius:1em;-webkit-border-top-right-radius:1em;-moz-border-radius-topright:1em;border-top-right-radius:1em;-webkit-border-bottom-right-radius:1em;-moz-border-radius-bottomright:1em;border-bottom-right-radius:1em;-webkit-border-bottom-left-radius:1em;-moz-border-radius-bottomleft:1em;border-bottom-left-radius:1em}')
-                         
+
     def test_flexbox(self):
         self.assertEqual(cssprefixer.process('a{-moz-display: box;}', minify=True),
-                         'a{display:-webkit-box;display:-moz-box;display:box}')  
-                         
+                         'a{display:-webkit-box;display:-moz-box;display:box}')
+
     def test_mq_common(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{-moz-border-radius: 1em}}', minify=True),
-                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')                        
-                         
+                         '@media screen and (min-width:480px){a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}}')
+
 class OperaPrefixerTestCase(unittest.TestCase):
     def test_common_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-o-transform: rotate(10deg)}', minify=True),
                          'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
-                         
+
     def test_ie_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-o-text-overflow: ellipsis}', minify=True),
-                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')                         
+                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')
 
 class IePrefixerTestCase(unittest.TestCase):
     def test_ie_and_opera(self):
         self.assertEqual(cssprefixer.process('a{-ms-text-overflow: ellipsis}', minify=True),
-                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')   
-             
+                         'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')
+
 class GradientTestCase(unittest.TestCase):
     def test_basic(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
@@ -250,8 +251,8 @@ class GradientTestCase(unittest.TestCase):
     background-image: -o-linear-gradient(top, #444, #999);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999)
-    }''') 
-    
+    }''')
+
     def test_linear_no_pos(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: linear-gradient(#444444, #999999);
@@ -262,7 +263,7 @@ class GradientTestCase(unittest.TestCase):
     background-image: -o-linear-gradient(#444, #999);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(#444, #999)
-    }''')     
+    }''')
 
     def test_webkit(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
@@ -274,8 +275,8 @@ class GradientTestCase(unittest.TestCase):
     background-image: -o-linear-gradient(top, #444, #999);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999)
-    }''')  
-        
+    }''')
+
     def test_webkit_mixed(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -webkit-linear-gradient(top, #444444, #999999), linear-gradient(top, black, white);
@@ -286,8 +287,8 @@ class GradientTestCase(unittest.TestCase):
     background-image: -o-linear-gradient(top, #444, #999), -o-linear-gradient(top, black, white);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999), linear-gradient(top, black, white)
-    }''')  
-    
+    }''')
+
     def test_moz(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -moz-linear-gradient(top, #444444, #999999);
@@ -298,8 +299,8 @@ class GradientTestCase(unittest.TestCase):
     background-image: -o-linear-gradient(top, #444, #999);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999)
-    }''') 
-    
+    }''')
+
     def test_o(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -o-linear-gradient(top, #444444, #999999);
@@ -311,7 +312,7 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999)
     }''')
-    
+
     def test_webkit_gradient(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
@@ -323,7 +324,7 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(#444, #999)
     }''')
-    
+
     def test_webkit_gradient_mixed(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-linear-gradient(top, black, white);
@@ -335,7 +336,7 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(#444, #999), linear-gradient(top, black, white)
     }''')
-    
+
     def test_image(self):
         #I don't think this test produces valid css but it shows that data and order is being preserved.
         self.assertEqual(cssprefixer.process('''.box_gradient {
@@ -348,14 +349,14 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
     background-image: url(images/background.png), linear-gradient(top, black, white)
     }''')
-    
+
     def test_background_multiple_images(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background: url(images/cross.png), url(images/gradient.png) top center no-repeat, url(images/background.png);
     }''', minify=False), '''.box_gradient {
     background: url(images/cross.png), url(images/gradient.png) top center no-repeat, url(images/background.png)
-    }''') 
-    
+    }''')
+
     def test_background_multiple_images_and_gradient(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png);
@@ -367,7 +368,7 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=black, EndColorStr=white)";
     background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png)
     }''')
-    
+
     def test_background_multiple_images_and_gradients(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), -moz-linear-gradient(top, #444444, #999999);
@@ -380,6 +381,6 @@ class GradientTestCase(unittest.TestCase):
     background: linear-gradient(top, black, white), url(images/gradient.png) top center no-repeat, url(images/background.png), linear-gradient(top, #444, #999)
     }''')
 
-  
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -92,9 +92,9 @@ class PrefixerTestCase(unittest.TestCase):
              
     def test_transition_property(self):
         self.assertEqual(cssprefixer.process('''div {
-  -webkit-transition-property: -webkit-transform, opacity, left;
-  -webkit-transition-duration: rotatey(45deg), 2s, 4s;
-}''', minify=False), '''div {
+    -webkit-transition-property: -webkit-transform, opacity, left;
+    -webkit-transition-duration: rotatey(45deg), 2s, 4s;
+    }''', minify=False), '''div {
     -webkit-transition-property: -webkit-transform, opacity, left;
     -moz-transition-property: -moz-transform, opacity, left;
     -o-transition-property: -o-transform, opacity, left;
@@ -104,7 +104,17 @@ class PrefixerTestCase(unittest.TestCase):
     -o-transition-duration: rotatey(45deg), 2s, 4s;
     transition-duration: rotatey(45deg), 2s, 4s
     }''')
-                         
+    
+    
+    def test_opacity(self):
+        self.assertEqual(cssprefixer.process('''a {
+    opacity: 0.25;
+    }''', minify=False), '''a {
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)";
+    filter: alpha(opacity=25);
+    opacity: 0.25
+    }''')    
+                 
     def test_no_mini(self):
         self.assertEqual(cssprefixer.process('''.my-class, #my-id {
     border-radius: 1em;

--- a/tests.py
+++ b/tests.py
@@ -61,21 +61,31 @@ class PrefixerTestCase(unittest.TestCase):
     def test_mixed_common(self):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
                          'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
-                         
+
+    def test_transition(self):
+        self.assertEqual(cssprefixer.process('''div {
+      -webkit-transition: color .25s linear, -webkit-transform .15s linear .1s;
+    }''', minify=False), '''div {
+    -webkit-transition: color 0.25s linear, -webkit-transform 0.15s linear 0.1s;
+    -moz-transition: color 0.25s linear, -moz-transform 0.15s linear 0.1s;
+    -o-transition: color 0.25s linear, -o-transform 0.15s linear 0.1s;
+    transition: color 0.25s linear, transform 0.15s linear 0.1s
+    }''')
+             
     def test_transition_property(self):
         self.assertEqual(cssprefixer.process('''div {
   -webkit-transition-property: -webkit-transform, opacity, left;
-  -webkit-transition-duration: 2s, 4s;
+  -webkit-transition-duration: rotatey(45deg), 2s, 4s;
 }''', minify=False), '''div {
     -webkit-transition-property: -webkit-transform, opacity, left;
     -moz-transition-property: -moz-transform, opacity, left;
     -o-transition-property: -o-transform, opacity, left;
     transition-property: transform, opacity, left;
-    -webkit-transition-duration: 2s, 4s;
-    -moz-transition-duration: 2s, 4s;
-    -o-transition-duration: 2s, 4s;
-    transition-duration: 2s, 4s
-    }''')                         
+    -webkit-transition-duration: rotatey(45deg), 2s, 4s;
+    -moz-transition-duration: rotatey(45deg), 2s, 4s;
+    -o-transition-duration: rotatey(45deg), 2s, 4s;
+    transition-duration: rotatey(45deg), 2s, 4s
+    }''')
                          
     def test_no_mini(self):
         self.assertEqual(cssprefixer.process('''.my-class, #my-id {

--- a/tests.py
+++ b/tests.py
@@ -56,11 +56,11 @@ class PrefixerTestCase(unittest.TestCase):
                          
     def test_duplicate_common(self):
         self.assertEqual(cssprefixer.process('a{border-radius: 1em;border-radius: 2em;border-radius: 3em}', minify=True),
-                         'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em;-webkit-border-radius:2em;-moz-border-radius:2em;border-radius:2em;-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
                          
     def test_mixed_common(self):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
-                         'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
+                         'a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em;-webkit-border-radius:2em;-moz-border-radius:2em;border-radius:2em;-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
 
     def test_transition(self):
         self.assertEqual(cssprefixer.process('''div {
@@ -75,19 +75,19 @@ class PrefixerTestCase(unittest.TestCase):
     #This test failes but it shouln't.
     #This failes becuase duplicate properties are removed,
     #this duplicate property is valid and useful.
-    def _test_multi_transition(self):
+    def test_multi_transition(self):
         self.assertEqual(cssprefixer.process('''div {
     transition: color .25s linear;
     transition: background-color .15s linear .1;
     }''', minify=False), '''div {
-    -webkit-transition: color .25s linear;
-    -moz-transition: color .25s linear;
-    -o-transition: color .25s linear;
-    transition: color .25s linear;
-    -webkit-transition: background-color .15s linear .1;
-    -moz-transition: background-color .15s linear .1;
-    -o-transition: background-color .15s linear .1;
-    transition: background-color .15s linear .1
+    -webkit-transition: color 0.25s linear;
+    -moz-transition: color 0.25s linear;
+    -o-transition: color 0.25s linear;
+    transition: color 0.25s linear;
+    -webkit-transition: background-color 0.15s linear 0.1;
+    -moz-transition: background-color 0.15s linear 0.1;
+    -o-transition: background-color 0.15s linear 0.1;
+    transition: background-color 0.15s linear 0.1
     }''')
              
     def test_transition_property(self):

--- a/tests.py
+++ b/tests.py
@@ -83,6 +83,10 @@ class PrefixerTestCase(unittest.TestCase):
     display: -moz-box;
     display: box;
 }''')
+
+    def test_empty(self):
+        self.assertEqual(cssprefixer.process('a{}', minify=True), '')
+        self.assertEqual(cssprefixer.process('a{}', minify=False), '')
                          
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):

--- a/tests.py
+++ b/tests.py
@@ -62,6 +62,21 @@ class PrefixerTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em}', minify=True),
                          'a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}')
                          
+    def test_transition_property(self):
+        self.assertEqual(cssprefixer.process('''div {
+  -webkit-transition-property: -webkit-transform, opacity, left;
+  -webkit-transition-duration: 2s, 4s;
+}''', minify=False), '''div {
+    -webkit-transition-property: -webkit-transform, opacity, left;
+    -moz-transition-property: -moz-transform, opacity, left;
+    -o-transition-property: -o-transform, opacity, left;
+    transition-property: transform, opacity, left;
+    -webkit-transition-duration: 2s, 4s;
+    -moz-transition-duration: 2s, 4s;
+    -o-transition-duration: 2s, 4s;
+    transition-duration: 2s, 4s
+    }''')                         
+                         
     def test_no_mini(self):
         self.assertEqual(cssprefixer.process('''.my-class, #my-id {
     border-radius: 1em;

--- a/tests.py
+++ b/tests.py
@@ -81,12 +81,25 @@ class PrefixerTestCase(unittest.TestCase):
     box-shadow: #123456 0 0 10px;
     display: -webkit-box;
     display: -moz-box;
-    display: box;
-}''')
+    display: box
+    }''')
 
     def test_empty(self):
         self.assertEqual(cssprefixer.process('a{}', minify=True), '')
         self.assertEqual(cssprefixer.process('a{}', minify=False), '')
+        
+    def test_media_no_mini(self):
+        self.assertEqual(cssprefixer.process('''@media screen and (max-device-width: 480px){
+    #book{
+        border-radius: 1em;
+    }
+}''', minify=False), '''@media screen and (max-device-width: 480px) {
+    #book {
+        -webkit-border-radius: 1em;
+        -moz-border-radius: 1em;
+        border-radius: 1em
+        }
+    }''')
                          
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):

--- a/tests.py
+++ b/tests.py
@@ -222,7 +222,7 @@ class IePrefixerTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('a{-ms-text-overflow: ellipsis}', minify=True),
                          'a{-o-text-overflow:ellipsis;-ms-text-overflow:ellipsis;text-overflow:ellipsis}')   
              
-class GradientTestCase(unittest.TestCase):            
+class GradientTestCase(unittest.TestCase):
     def test_basic(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: linear-gradient(top, #444444, #999999);
@@ -234,6 +234,18 @@ class GradientTestCase(unittest.TestCase):
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
     background-image: linear-gradient(top, #444, #999)
     }''') 
+    
+    def test_linear_no_pos(self):
+        self.assertEqual(cssprefixer.process('''.box_gradient {
+    background-image: linear-gradient(#444444, #999999);
+    }''', minify=False), '''.box_gradient {
+    background-image: -webkit-linear-gradient(#444, #999);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
+    background-image: -moz-linear-gradient(#444, #999);
+    background-image: -o-linear-gradient(#444, #999);
+    filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
+    background-image: linear-gradient(#444, #999)
+    }''')     
 
     def test_webkit(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
@@ -287,24 +299,24 @@ class GradientTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
     }''', minify=False), '''.box_gradient {
-    background-image: -webkit-linear-gradient(top, #444, #999);
+    background-image: -webkit-linear-gradient(#444, #999);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999));
-    background-image: -moz-linear-gradient(top, #444, #999);
-    background-image: -o-linear-gradient(top, #444, #999);
+    background-image: -moz-linear-gradient(#444, #999);
+    background-image: -o-linear-gradient(#444, #999);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
-    background-image: linear-gradient(top, #444, #999)
+    background-image: linear-gradient(#444, #999)
     }''')
     
     def test_webkit_gradient_mixed(self):
         self.assertEqual(cssprefixer.process('''.box_gradient {
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-linear-gradient(top, black, white);
     }''', minify=False), '''.box_gradient {
-    background-image: -webkit-linear-gradient(top, #444, #999), -webkit-linear-gradient(top, black, white);
+    background-image: -webkit-linear-gradient(#444, #999), -webkit-linear-gradient(top, black, white);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #444), color-stop(1, #999)), -webkit-gradient(linear, left top, left bottom, color-stop(0, black), color-stop(1, white));
-    background-image: -moz-linear-gradient(top, #444, #999), -moz-linear-gradient(top, black, white);
-    background-image: -o-linear-gradient(top, #444, #999), -o-linear-gradient(top, black, white);
+    background-image: -moz-linear-gradient(#444, #999), -moz-linear-gradient(top, black, white);
+    background-image: -o-linear-gradient(#444, #999), -o-linear-gradient(top, black, white);
     filter: "progid:DXImageTransform.Microsoft.gradient(startColorStr=#444, EndColorStr=#999)";
-    background-image: linear-gradient(top, #444, #999), linear-gradient(top, black, white)
+    background-image: linear-gradient(#444, #999), linear-gradient(top, black, white)
     }''')
     
     def test_image(self):

--- a/tests.py
+++ b/tests.py
@@ -26,9 +26,21 @@ class PrefixerTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('a{transform: rotate(10deg)}', minify=True),
                          'a{-webkit-transform:rotate(10deg);-moz-transform:rotate(10deg);-o-transform:rotate(10deg);transform:rotate(10deg)}')
 
+    def test_undefined(self):
+        #test prefixed styles that don't have a rule yet, we use a fake property 
+        #for this test becuase we will never have a rule for this
+        self.assertEqual(cssprefixer.process('a{-webkit-faker: black}', minify=True),
+                         'a{-webkit-faker:black}')
+
     def test_webkit(self):
         self.assertEqual(cssprefixer.process('a{background-clip: padding-box}', minify=True),
                          'a{-webkit-background-clip:padding-box;background-clip:padding-box}')
+
+    def test_appearance(self):
+        #test prefixed styles that don't have a rule yet, we use a fake property 
+        #for this test becuase we will never have a rule for this
+        self.assertEqual(cssprefixer.process('a{-webkit-appearance: none;}', minify=True),
+                         'a{-webkit-appearance:none;appearance:none}')
 
     def test_ie_and_opera(self):
         self.assertEqual(cssprefixer.process('a{text-overflow: ellipsis}', minify=True),

--- a/tests.py
+++ b/tests.py
@@ -71,6 +71,24 @@ class PrefixerTestCase(unittest.TestCase):
     -o-transition: color 0.25s linear, -o-transform 0.15s linear 0.1s;
     transition: color 0.25s linear, transform 0.15s linear 0.1s
     }''')
+    
+    #This test failes but it shouln't.
+    #This failes becuase duplicate properties are removed,
+    #this duplicate property is valid and useful.
+    def _test_multi_transition(self):
+        self.assertEqual(cssprefixer.process('''div {
+    transition: color .25s linear;
+    transition: background-color .15s linear .1;
+    }''', minify=False), '''div {
+    -webkit-transition: color .25s linear;
+    -moz-transition: color .25s linear;
+    -o-transition: color .25s linear;
+    transition: color .25s linear;
+    -webkit-transition: background-color .15s linear .1;
+    -moz-transition: background-color .15s linear .1;
+    -o-transition: background-color .15s linear .1;
+    transition: background-color .15s linear .1
+    }''')
              
     def test_transition_property(self):
         self.assertEqual(cssprefixer.process('''div {

--- a/tests.py
+++ b/tests.py
@@ -100,6 +100,15 @@ class PrefixerTestCase(unittest.TestCase):
         border-radius: 1em
         }
     }''')
+    
+    def test_comment(self):
+        self.assertEqual(cssprefixer.process('''/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    display: block
+    }''', minify=False), '''/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+    display: block
+    }''')
                          
 class WebkitPrefixerTestCase(unittest.TestCase):
     def test_common(self):

--- a/tests.py
+++ b/tests.py
@@ -41,6 +41,10 @@ class PrefixerTestCase(unittest.TestCase):
     def test_flexbox(self):
         self.assertEqual(cssprefixer.process('a{display: box;}', minify=True),
                          'a{display:-webkit-box;display:-moz-box;display:box}')
+                         
+    def test_displaybox(self):
+        self.assertEqual(cssprefixer.process('a{display: display;}', minify=True),
+                         'a{display:display}')
 
     def test_mq(self):
         self.assertEqual(cssprefixer.process('@media screen and (min-width:480px){a{color:red}}', minify=True),


### PR DESCRIPTION
Properties with vendor prefixes can be used:
    a{-webkit-border-radius: 1em} -> a{-webkit-border-radius:1em;-moz-border-radius:1em;border-radius:1em}

Duplicate properties are cleaned up:
    a{border-radius: 1em;border-radius: 2em;border-radius: 3em} -> a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}
The value of the last property wins, just like it would be if the css was unchanged due to it's cascading nature.

Even mixed duplicate properties are cleaned up:
    a{-moz-border-radius: 1em;border-radius: 2em;-webkit-border-radius: 3em} -> a{-webkit-border-radius:3em;-moz-border-radius:3em;border-radius:3em}

All of these changes have been vetted with unittests.

This update also makes the resulting css cleaner because the properties are grouped together:

.my-class, #my-id {
    -webkit-border-radius: 1em;
    -moz-border-radius: 1em;
    border-radius: 1em;
    -webkit-transition: all 1s ease;
    -moz-transition: all 1s ease;
    -o-transition: all 1s ease;
    transition: all 1s ease;
    -webkit-box-shadow: #123456 0 0 10px;
    -moz-box-shadow: #123456 0 0 10px;
    box-shadow: #123456 0 0 10px
}

instead of

.my-class, #my-id {
    -moz-border-radius: 1em;
    -o-transition: all 1s ease;
    -moz-box-shadow: #123456 0 0 10px;
    -webkit-box-shadow: #123456 0 0 10px;
    -moz-transition: all 1s ease;
    -webkit-transition: all 1s ease;
    -webkit-border-radius: 1em;
    border-radius: 1em;
    transition: all 1s ease;
    box-shadow: #123456 0 0 10px
}
