### PR TITLE
fix unicode error

### DIFF
--- a/scripts/cssprefixer
+++ b/scripts/cssprefixer
@@ -34,7 +34,10 @@ if __name__ == '__main__':
         for arg in sys.argv[1:]:
             if arg[:2] != '--':
                 result += cssprefixer.process(open(arg, 'r').read(), debug, minify)
-        print result
+        try:
+            print result
+        except UnicodeEncodeError:
+            print result.encode('utf8')
     else:
         print "Usage: cssprefixer <filenames> <options>"
         print "Options:" + reduce(lambda a, b: '%s --%s' % (a, b), options, '') # Javascript's Array.join, haha


### PR DESCRIPTION
I was having the same error as the guy in the closed bug.  Looked thru my files, couldn't find a non-ascii character.  Even wrote a program to print out the maximum size of all the chars in the file, never went over 126.  Not sure what the problem is.  Oh well, the pulled code fixed it.  

I guess it's not a perfect fix if your terminal isn't set to utf8, but modern ones are.  And it should crash in fewer circumstances, better than nothing.
