### PR TITLE
Properly support keyframes and animation

### DIFF
--- a/cssprefixer/engine.py
+++ b/cssprefixer/engine.py
@@ -22,13 +22,15 @@ from rules import prefixRegex
 def magic(ruleset, debug, minify, filt, parser):
     if isinstance(ruleset, cssutils.css.CSSUnknownRule):
         if ruleset.cssText.startswith('@keyframes'):
-            inner = parser.parseString(re.split(r'@keyframes\s?\w+\s?{(.*)}', ruleset.cssText.replace('\n', ''))[1])
+            parts = re.split(r'@keyframes\s?(\w+)\s?{(.*)}', ruleset.cssText.replace('\n', ''))
+            name = parts[1]
+            inner = parser.parseString(parts[2])
             # TODO: DRY, un-mess this up
             # BUG: doesn't work when minified
             s = '' if minify else '\n'
-            return '@-webkit-keyframes {' + s + \
+            return '@-webkit-keyframes %s {'%name + s + \
             ''.join([magic(rs, debug, minify, ['webkit'], parser) for rs in inner]) \
-            + '}' + s + '@-moz-keyframes {' + s + \
+            + '}' + s + '@-moz-keyframes %s {'%name + s + \
             ''.join([magic(rs, debug, minify, ['moz'], parser) for rs in inner]) \
             + '}' + s + ruleset.cssText
         elif ruleset.cssText.startswith('from') or ruleset.cssText.startswith('to'):

--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -245,6 +245,7 @@ class GradientReplacementRule(BaseReplacementRule):
         return self.__get_prefixed_prop(values)
 
 rules = {
+    'animation': FullReplacementRule,
     'border-radius': BaseReplacementRule,
     'border-top-left-radius': BorderRadiusReplacementRule,
     'border-top-right-radius': BorderRadiusReplacementRule,

--- a/tests.py
+++ b/tests.py
@@ -411,17 +411,17 @@ class GradientTestCase(unittest.TestCase):
         self.assertEqual(cssprefixer.process('''@keyframes round {
     from {border-radius: 2px}
     to {border-radius: 10px}
-    }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+    }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
         self.assertEqual(cssprefixer.process('''@keyframes round {
     0% {border-radius: 2px}
     100% {border-radius: 10px}
-    }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+    }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
         self.assertEqual(cssprefixer.process('''@-webkit-keyframes round {
     0% {border-radius: 2px}
     100% {border-radius: 10px}
-    }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+    }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
     def test_animation(self):
         self.assertEqual(cssprefixer.process('a{animation: foo 1s}', minify=True),

--- a/tests.py
+++ b/tests.py
@@ -413,6 +413,16 @@ class GradientTestCase(unittest.TestCase):
     to {border-radius: 10px}
     }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
+        self.assertEqual(cssprefixer.process('''@keyframes round {
+    0% {border-radius: 2px}
+    100% {border-radius: 10px}
+    }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+
+        self.assertEqual(cssprefixer.process('''@-webkit-keyframes round {
+    0% {border-radius: 2px}
+    100% {border-radius: 10px}
+    }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+
     def test_animation(self):
         self.assertEqual(cssprefixer.process('a{animation: foo 1s}', minify=True),
                          'a{-moz-animation:foo 1s;-ms-animation:foo 1s;-o-animation:foo 1s;-webkit-animation:foo 1s;animation:foo 1s}')

--- a/tests.py
+++ b/tests.py
@@ -413,5 +413,10 @@ class GradientTestCase(unittest.TestCase):
     to {border-radius: 10px}
     }''', minify=False), "@-webkit-keyframes {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
+    def test_animation(self):
+        self.assertEqual(cssprefixer.process('a{animation: foo 1s}', minify=True),
+                         'a{-moz-animation:foo 1s;-ms-animation:foo 1s;-o-animation:foo 1s;-webkit-animation:foo 1s;animation:foo 1s}')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -413,11 +413,19 @@ class GradientTestCase(unittest.TestCase):
     to {border-radius: 10px}
     }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
+        # Test with comment within the keyframes definition.
+        self.assertEqual(cssprefixer.process('''@keyframes round /* comment */ {
+    from {border-radius: 2px}
+    to {border-radius: 10px}
+    }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+
+        # Test with percentage values.
         self.assertEqual(cssprefixer.process('''@keyframes round {
     0% {border-radius: 2px}
     100% {border-radius: 10px}
-    }''', minify=False), "@-webkit-keyframes round {\nfrom {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
+    }''', minify=False), "@-webkit-keyframes round {\0% {\n    -webkit-border-radius: 2px;\n    border-radius: 2px\n    }\n100% {\n    -webkit-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@-moz-keyframes round {\nfrom {\n    -moz-border-radius: 2px;\n    border-radius: 2px\n    }\nto {\n    -moz-border-radius: 10px;\n    border-radius: 10px\n    }\n}\n@keyframes round {\n    from {\n        border-radius: 2px\n        } to {\n        border-radius: 10px\n        }\n    }")
 
+        # Test with vendor-prefix in input.
         self.assertEqual(cssprefixer.process('''@-webkit-keyframes round {
     0% {border-radius: 2px}
     100% {border-radius: 10px}


### PR DESCRIPTION
There are multiple problems with this currently.
- animation is not rewritten. This is added in e2b11d27 here.
- keyframe rewrite fails when already prefixed in the input (the rule is removed entirely).
- keyframe rewrite doesn't work with percentage values, only "from" and "to". This last one is hard to solve, because cssutils refuses to parse it. cssutils is under active development. I would think that the best way to solve this would be to properly support @keyframes there.
