### PR TITLE
Allow pre-prefixed radial-gradient values

### DIFF
--- a/cssprefixer/rules.py
+++ b/cssprefixer/rules.py
@@ -156,7 +156,8 @@ class GradientReplacementRule(BaseReplacementRule):
         while(True):
             if index >= len(valueSplit):
                 break
-            snip = prefixRegex.sub('', valueSplit[index].strip())
+            rawValue = valueSplit[index].strip()
+            snip = prefixRegex.sub('', rawValue)
             if snip.startswith('linear-gradient'):
                 values = [re.sub('^linear-gradient\(', '', snip)]
                 if valueSplit[index + 1].strip().endswith(')'):
@@ -184,7 +185,7 @@ class GradientReplacementRule(BaseReplacementRule):
                 index += 7
             else:
                 # not a gradient so just yield the raw string
-                yield snip
+                yield rawValue
                 index += 1
 
     def __get_prefixed_prop(self, values, prefix=None):


### PR DESCRIPTION
Input:

``` css
body {
  background-image: -moz-radial-gradient(top center, ellipse farthest-side, red, yellow, green);
}
```

Before change: vendor prefix is stripped

``` css
body {
  background-image: radial-gradient(top center, ellipse farthest-side, red, yellow, green);
}
```

After change: vendor prefix is no longer stripped

``` css
body {
  background-image: -moz-radial-gradient(top center, ellipse farthest-side, red, yellow, green);
}
```
